### PR TITLE
Corrects `init-repo.sh` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 The model name in this script will become your output directory for following scripts.
 
 ```sh
-bash init-repo.sh
+bash scripts/init-repo.sh
 ```
 
 #### Create Repo (on HuggingFace)


### PR DESCRIPTION
For `make-all.sh` the path is prefixed with `scripts/` as it should be. This minor change does the same for `init-repo.sh`